### PR TITLE
chore: update nginx base image to 1.30.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.19
+FROM nginx:1.30.1
 
 ENV PORT 80
 ENV WORK_DIR /tmp


### PR DESCRIPTION
Bump nginx base image from 1.19 to 1.30.1 (stable) to address the NGINX Rift security vulnerability (CVE-2026-42945).

Refs: SBE-1416